### PR TITLE
Add support to SBOM standards

### DIFF
--- a/examples/security-insights-sample.yml
+++ b/examples/security-insights-sample.yml
@@ -97,3 +97,8 @@ dependencies:
   third-party-packages: true
   dependencies-lists:
   - https://github.com/foo/packages.json
+  sbom:
+  - sbom-file: https://foo.bar/sbom
+    sbom-name: CycloneDX
+    sbom-url: https://foo.bar
+    

--- a/security-insights-schema-1.0.0.yaml
+++ b/security-insights-schema-1.0.0.yaml
@@ -485,6 +485,32 @@ properties:
                         type: string
                         format: iri
                         pattern: '^https?:\/\/'
+            sbom:
+                $id: '#/properties/dependencies/properties/sbom'
+                additionalItems: false
+                items:
+                    anyOf:
+                    -   $id: '#/properties/dependencies/properties/sbom/items'
+                        additionalProperties: false
+                        properties:
+                            sbom-file:
+                                $id: '#/properties/distribution-points/items/anyOf/0/properties/sbom-file'
+                                description: 'Link to the SBOM file.'
+                                type: string
+                                format: iri
+                                pattern: '^https?:\/\/'
+                            sbom-name:
+                                $id: '#/properties/distribution-points/items/anyOf/0/properties/sbom-name'
+                                description: 'Name of the SBOM standard used.'
+                                type: string
+                            sbom-url:
+                                $id: '#/properties/distribution-points/items/anyOf/0/properties/sbom-url'
+                                description: 'Link to the SBOM standard website or documentation.'
+                                type: string
+                                format: iri
+                                pattern: '^https?:\/\/'
+                type: array
+                uniqueItems: true
         if:
             properties:
                 third-party-packages:


### PR DESCRIPTION
Added support to SBOM standards. Users can add links to SBOM files directly in the `SECURITY-INSIGHTS.yml`.