### PR TITLE
Add support for PURLs

### DIFF
--- a/examples/security-insights-minimal-sample.yml
+++ b/examples/security-insights-minimal-sample.yml
@@ -15,8 +15,8 @@ contribution-policy:
   accepts-pull-requests: true
   accepts-bot-pull-requests: true
 distribution-points:
-- package-url: https://foo.bar/package
-- package-url: pkg:npm/foobar
+- https://foo.bar/package
+- pkg:npm/foobar
 security-artifacts:
   threat-model:
     threat-model-created: false

--- a/examples/security-insights-minimal-sample.yml
+++ b/examples/security-insights-minimal-sample.yml
@@ -13,8 +13,10 @@ project-lifecycle:
   - https://github.com/scovetta
 contribution-policy:
   accepts-pull-requests: true
+  accepts-bot-pull-requests: true
 distribution-points:
 - package-url: https://foo.bar/package
+- package-url: pkg:npm/foobar
 security-artifacts:
   threat-model:
     threat-model-created: false

--- a/examples/security-insights-sample.yml
+++ b/examples/security-insights-sample.yml
@@ -24,12 +24,8 @@ contribution-policy:
 documentation:
 - http://foo.bar/wiki
 distribution-points:
-- ecosystem: npm
-  package-name: foo
-  package-url: https://example.com/foo
-- ecosystem: npm
-  package-name: foo
-  package-url: pkg:npm/foobar
+- https://example.com/foo
+- pkg:npm/foobar
 security-artifacts:
   threat-model:
     threat-model-created: true

--- a/examples/security-insights-sample.yml
+++ b/examples/security-insights-sample.yml
@@ -18,6 +18,7 @@ project-lifecycle:
   - joe.bob@email.com
 contribution-policy:
   accepts-pull-requests: true
+  accepts-bot-pull-requests: true
   contributing-policy: https://example.com/development-policy.html
   code-of-conduct: https://example.com/code-of-conduct.html
 documentation:
@@ -26,6 +27,9 @@ distribution-points:
 - ecosystem: npm
   package-name: foo
   package-url: https://example.com/foo
+- ecosystem: npm
+  package-name: foo
+  package-url: pkg:npm/foobar
 security-artifacts:
   threat-model:
     threat-model-created: true

--- a/security-insights-schema-1.0.0.yaml
+++ b/security-insights-schema-1.0.0.yaml
@@ -178,10 +178,8 @@ properties:
                         type: string
                     package-url:
                         $id: '#/properties/distribution-points/items/anyOf/0/properties/package-url'
-                        description: 'Link to the package.'
+                        description: 'Link (PURL/URL) to the package.'
                         type: string
-                        format: iri
-                        pattern: '^https?:\/\/'
                 required:
                 - package-url
                 type: object

--- a/security-insights-schema-1.0.0.yaml
+++ b/security-insights-schema-1.0.0.yaml
@@ -166,23 +166,8 @@ properties:
             $id: '#/properties/distribution-points/items'
             anyOf:
             -   $id: '#/properties/distribution-points/items/anyOf/0'
-                additionalProperties: false
-                properties:
-                    ecosystem:
-                        $id: '#/properties/distribution-points/items/anyOf/0/properties/ecosystem'
-                        description: 'The package manager in which the package is deployed.'
-                        type: string
-                    package-name:
-                        $id: '#/properties/distribution-points/items/anyOf/0/properties/package-name'
-                        description: 'Name of the package in the package manager.'
-                        type: string
-                    package-url:
-                        $id: '#/properties/distribution-points/items/anyOf/0/properties/package-url'
-                        description: 'Link (PURL/URL) to the package.'
-                        type: string
-                required:
-                - package-url
-                type: object
+                description: 'Link (PURL/URL) to the package.'
+                type: string
         type: array
         uniqueItems: true
     security-artifacts:


### PR DESCRIPTION
This PR should solve https://github.com/ossf/security-insights-spec/issues/20. Now, `package-url` supports the PURL. `ecosystem` and `package-name` are still optional but supported, just in case maintainers want to publish an artifact on an ad-hoc server (e.g. `https://example.com/my-tool-latest.exe`).