### PR TITLE
Security Artifacts Schema Change

### DIFF
--- a/examples/security-insights-sample.yml
+++ b/examples/security-insights-sample.yml
@@ -65,6 +65,19 @@ security-artifacts:
       in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
       sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt
       mollit anim id est laborum
+  other-artifacts:
+    - artifact-name: example-artifact
+      artifact-created: true
+      evidence-url:
+      - https://foo.com/artifact.html
+      comment: |
+        Lorem ipsum dolor sit amet, consectetur adipisci elit,
+        sed do eiusmod tempor incidunt ut labore et dolore magna aliqua.
+        Ut enim ad minim veniam, quis nostrum exercitationem ullamco laboriosam,
+        nisi ut aliquid ex ea commodi consequatur. Duis aute irure reprehenderit
+        in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
+        sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt
+        mollit anim id est laborum
 security-testing:
 - tool-type: sast
   tool-name: CodeQL

--- a/examples/security-insights-sample.yml
+++ b/examples/security-insights-sample.yml
@@ -53,6 +53,18 @@ security-artifacts:
       in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
       sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt
       mollit anim id est laborum
+  self-assessment:
+    self-assessment-created: true
+    evidence-url:
+    - https://foo.com/assessment.html
+    comment: |
+      Lorem ipsum dolor sit amet, consectetur adipisci elit,
+      sed do eiusmod tempor incidunt ut labore et dolore magna aliqua.
+      Ut enim ad minim veniam, quis nostrum exercitationem ullamco laboriosam,
+      nisi ut aliquid ex ea commodi consequatur. Duis aute irure reprehenderit
+      in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
+      sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt
+      mollit anim id est laborum
 security-testing:
 - tool-type: sast
   tool-name: CodeQL

--- a/security-insights-schema-1.0.0.yaml
+++ b/security-insights-schema-1.0.0.yaml
@@ -251,8 +251,82 @@ properties:
                 required:
                 - threat-model-created
                 type: object
-        required:
-        - threat-model
+            self-assessment:
+                $id: '#/properties/security-artifacts/properties/self-assessment'
+                additionalProperties: false
+                properties:
+                    self-assessment-created:
+                        $id: '#/properties/security-artifacts/properties/self-assessment/properties/self-assessment-created'
+                        description: 'Define whether a security self assessment for the project has been created. A false value may be used to add comments regarding the status of the assessment.'
+                        type: boolean
+                    evidence-url:
+                        $id: '#/properties/security-artifacts/properties/self-assessment/properties/evidence-url'
+                        additionalItems: false
+                        items:
+                            $id: '#/properties/security-artifacts/properties/self-assessment/properties/evidence-url/items'
+                            anyOf:
+                            -   $id: '#/properties/security-artifacts/properties/self-assessment/properties/evidence-url/items/anyOf/0'
+                                description: 'Link to the evidence of the security self assessment.'
+                                type: string
+                                format: iri
+                                pattern: '^https?:\/\/'
+                        type: array
+                        uniqueItems: true
+                    comment:
+                        $id: '#/properties/security-artifacts/properties/self-assessment/properties/comment'
+                        description: 'Additional context regarding the security self assessment or its status. Maximum length 560 chars.'
+                        type: string
+                        pattern: '^(.|\n){1,560}$'
+                if:
+                    properties:
+                        self-assessment-created:
+                            const: true
+                then:
+                    required:
+                    - evidence-url
+                required:
+                - self-assessment-created
+                type: object
+            other-artifacts:
+                $id: '#/properties/security-artifacts/properties/other-artifacts'
+                anyOf:
+                -   $id: '#/properties/security-testing/items/anyOf/0'
+                    additionalProperties: false
+                    properties:
+                        artifact-name: 
+                            $id: '#/properties/security-artifacts/properties/other-artifacts/anyOf/0/properties/name'
+                            description: 'Name of the security artifact.'
+                            type: string
+                        artifact-created:
+                            $id: '#/properties/security-artifacts/properties/other-artifacts/anyOf/0/properties/artifact-created'
+                            description: 'Define whether this artifact has been created. A false value may be used to add comments regarding the status of the artifact.'
+                            type: boolean
+                        evidence-url:
+                            $id: '#/properties/security-artifacts/properties/other-artifacts/anyOf/0/properties/evidence-url'
+                            additionalItems: false
+                            items:
+                                $id: '#/properties/security-artifacts/properties/other-artifacts/anyOf/0/properties/evidence-url/items'
+                                anyOf:
+                                -   $id: '#/properties/security-artifacts/properties/other-artifacts/anyOf/0/properties/evidence-url/items/anyOf/0'
+                                    description: 'Link to the evidence of the security artifact.'
+                                    type: string
+                                    format: iri
+                                    pattern: '^https?:\/\/'
+                            type: array
+                            uniqueItems: true
+                        comment:
+                            $id: '#/properties/security-artifacts/properties/self-assessment/anyOf/0/properties/comment'
+                            description: 'Additional context regarding the security artifact or its status. Maximum length 560 chars.'
+                            type: string
+                            pattern: '^(.|\n){1,560}$'
+                    if:
+                        properties:
+                            artifact-created:
+                                const: true
+                    then:
+                        required:
+                        - evidence-url
+                    type: object
         type: object
     security-testing:
         $id: '#/properties/security-testing'


### PR DESCRIPTION
This addresses #30 

The following changes have been made to the `security-artifacts` schema:

- Added object `self-assessment` ➕ 
- Added list object `other-artifacts` which takes arbitrary entries ➕ 
- Removed requirement for `threat-model` ❗ 