### PR TITLE
Changed 'sbom-name' value to 'sbom-format'

### DIFF
--- a/examples/security-insights-sample.yml
+++ b/examples/security-insights-sample.yml
@@ -113,6 +113,6 @@ dependencies:
   - https://github.com/foo/packages.json
   sbom:
   - sbom-file: https://foo.bar/sbom
-    sbom-name: CycloneDX
+    sbom-format: CycloneDX
     sbom-url: https://foo.bar
     

--- a/security-insights-schema-1.0.0.yaml
+++ b/security-insights-schema-1.0.0.yaml
@@ -528,8 +528,8 @@ properties:
                                 type: string
                                 format: iri
                                 pattern: '^https?:\/\/'
-                            sbom-name:
-                                $id: '#/properties/dependencies/items/anyOf/0/properties/sbom-name'
+                            sbom-format:
+                                $id: '#/properties/dependencies/items/anyOf/0/properties/sbom-format'
                                 description: 'Name of the SBOM standard used.'
                                 type: string
                             sbom-url:


### PR DESCRIPTION
This addresses #25 

Previously the value `sbom-name` was used to specify the format of the SBOM (CycloneDX or SPDX). This PR changes that value to `sbom-format` to increase clarity for users.