### PR TITLE
Extend dependencies schema

### DIFF
--- a/examples/security-insights-minimal-sample.yml
+++ b/examples/security-insights-minimal-sample.yml
@@ -1,10 +1,6 @@
 header:
   schema-version: '1.0.0'
-  parent-security-yaml: https://blah.com/ossf-security.yaml
   expiration-date: '2023-08-31T10:10:09.000Z'
-  last-updated: '2021-09-01'
-  last-reviewed: '2022-09-01'
-  commit-hash: 4dbf78ebc006ee5f668c0a74876ef8d6db9485be
   project-url: https://github.com/foo/bar
 project-lifecycle:
   stage: active
@@ -17,15 +13,8 @@ contribution-policy:
 distribution-points:
 - https://foo.bar/package
 - pkg:npm/foobar
-security-artifacts:
-  threat-model:
-    threat-model-created: false
 security-contacts:
 - type: email
   value: joe.bob@email.com
 vulnerability-reporting:
   accepts-vulnerability-reports: false
-dependencies:
-  third-party-packages: true
-  dependencies-lists:
-  - https://github.com/foo/packages.json

--- a/examples/security-insights-sample.yml
+++ b/examples/security-insights-sample.yml
@@ -66,23 +66,23 @@ security-artifacts:
       sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt
       mollit anim id est laborum
   other-artifacts:
-    - artifact-name: example-artifact
-      artifact-created: true
-      evidence-url:
+    artifact-name: example-artifact
+    artifact-created: true
+    evidence-url:
       - https://foo.com/artifact.html
-      comment: |
-        Lorem ipsum dolor sit amet, consectetur adipisci elit,
-        sed do eiusmod tempor incidunt ut labore et dolore magna aliqua.
-        Ut enim ad minim veniam, quis nostrum exercitationem ullamco laboriosam,
-        nisi ut aliquid ex ea commodi consequatur. Duis aute irure reprehenderit
-        in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
-        sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt
-        mollit anim id est laborum
+    comment: |
+      Lorem ipsum dolor sit amet, consectetur adipisci elit,
+      sed do eiusmod tempor incidunt ut labore et dolore magna aliqua.
+      Ut enim ad minim veniam, quis nostrum exercitationem ullamco laboriosam,
+      nisi ut aliquid ex ea commodi consequatur. Duis aute irure reprehenderit
+      in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
+      sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt
+      mollit anim id est laborum
 security-testing:
-- tool-type: sast
-  tool-name: CodeQL
+- tool-type: sca
+  tool-name: Dependabot
   tool-version: 1.2.3
-  tool-url: https://codeql.com
+  tool-url: https://example.org
   tool-rulesets:
   - built-in
   integration:
@@ -140,4 +140,24 @@ dependencies:
   - sbom-file: https://foo.bar/sbom
     sbom-format: CycloneDX
     sbom-url: https://foo.bar
+  dependencies-lifecycle:
+    policy-url: https://example.org
+    comment: |
+      Lorem ipsum dolor sit amet, consectetur adipisci elit,
+      sed do eiusmod tempor incidunt ut labore et dolore magna aliqua.
+      Ut enim ad minim veniam, quis nostrum exercitationem ullamco laboriosam,
+      nisi ut aliquid ex ea commodi consequatur. Duis aute irure reprehenderit
+      in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
+      sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt
+      mollit anim id est laborum
+  env-dependencies-policy:
+    policy-url: https://example.org
+    comment: |
+      Lorem ipsum dolor sit amet, consectetur adipisci elit,
+      sed do eiusmod tempor incidunt ut labore et dolore magna aliqua.
+      Ut enim ad minim veniam, quis nostrum exercitationem ullamco laboriosam,
+      nisi ut aliquid ex ea commodi consequatur. Duis aute irure reprehenderit
+      in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
+      sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt
+      mollit anim id est laborum
     

--- a/security-insights-schema-1.0.0.yaml
+++ b/security-insights-schema-1.0.0.yaml
@@ -61,7 +61,6 @@ properties:
                 format: iri
                 pattern: '^https?:\/\/'
         required:
-        - parent-security-yaml
         - expiration-date
         - project-url
         - schema-version
@@ -372,9 +371,9 @@ properties:
                         uniqueItems: true
                     tool-type:
                         $id: '#/properties/security-testing/items/anyOf/0/properties/tool-type'
-                        description: 'Type of security test: `sast`, `dast`, `iast` or `fuzzer`.'
+                        description: 'Type of security test: `sast`, `dast`, `iast`, `fuzzer` or `sca`.'
                         type: string
-                        enum: ['sast', 'dast', 'iast', 'fuzzer']
+                        enum: ['sast', 'dast', 'iast', 'fuzzer', 'sca']
                     tool-url:
                         $id: '#/properties/security-testing/items/anyOf/0/properties/tool-url'
                         description: 'Link to the security test.'
@@ -616,23 +615,44 @@ properties:
                                 pattern: '^(.|\n){1,560}$'
                 type: array
                 uniqueItems: true
-        if:
-            properties:
-                third-party-packages:
-                    const: true
-        then:
-            required:
-            - dependencies-lists
-        required:
-        - third-party-packages
+            dependencies-lifecycle:
+                $id: '#/properties/dependencies/properties/dependencies-lifecycle'
+                additionalProperties: false
+                properties:
+                    policy-url:
+                        $id: '#/properties/dependencies/properties/dependencies-lifecycle/properties/policy-url'
+                        description: 'Link to the dependencies lifecycle policy.'
+                        type: string
+                        format: iri
+                        pattern: '^https?:\/\/'
+                    comment:
+                        $id: '#/properties/dependencies/properties/dependencies-lifecycle/properties/comment'
+                        description: 'Summary about the dependencies lifecycle policy, third-party packages updating process, and deprecation process. Maximum length 560 chars.'
+                        type: string
+                        pattern: '^(.|\n){1,560}$'
+                type: object
+            env-dependencies-policy:
+                $id: '#/properties/dependencies/properties/env-dependencies-policy'
+                additionalProperties: false
+                properties:
+                    policy-url:
+                        $id: '#/properties/dependencies/properties/env-dependencies-policy/properties/policy-url'
+                        description: 'Link to the enviroment dependencies policy.'
+                        type: string
+                        format: iri
+                        pattern: '^https?:\/\/'
+                    comment:
+                        $id: '#/properties/dependencies/properties/env-dependencies-policy/properties/comment'
+                        description: 'Summary about how third-party dependencies are adopted and consumed in the different environments (dev, test, prod). Maximum length 560 chars.'
+                        type: string
+                        pattern: '^(.|\n){1,560}$'
+                type: object
         type: object
 required:
 - header
 - project-lifecycle
 - contribution-policy
 - distribution-points
-- security-artifacts
 - security-contacts
 - vulnerability-reporting
-- dependencies
 type: object


### PR DESCRIPTION
This PR should solve https://github.com/ossf/security-insights-spec/issues/28.

+ `dependencies-lifecycle` 
+ `env-dependencies-policy`

(I changed the suggested names but have no strong opinion, I have tried to reuse terms already used in security standards and certifications)

+ `sca` in `tool-type`

Fixed an example, and removed some requirements. 