### PR TITLE
Doc: Fix WG name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ If you find issues or inconsistencies in the specification, please [open an issu
 
 Our team will review your contributions and provide feedback. Once approved, we'll merge your changes.
 
-Reach out to us on [Slack](https://openssf.slack.com/messages/security_insights) or join a [community meeting](https://calendar.google.com/calendar?cid=czYzdm9lZmhwNWk5cGZsdGI1cTY3bmdwZXNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ) for the Identifying Security Threats Working Group.
+Reach out to us on [Slack](https://openssf.slack.com/messages/security_insights) or join a [community meeting](https://calendar.google.com/calendar?cid=czYzdm9lZmhwNWk5cGZsdGI1cTY3bmdwZXNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ) for the Metrics & Metadata working group.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Wecome to the official GitHub repository for the spec behind SECURITY-INSIGHTS.y
 
 All information regarding the maintenance, security, and consumption of the Security Insights Specification can be found in this repo within the latest version of the [official specification file](/specification.md).
 
-Don't forget to join us on Slack, and visit the OpenSSF Working Group responsible for maintaining this spec, [Identifying Security Threats in Open Source Projects](https://github.com/ossf/wg-identifying-security-threats).
+Don't forget to join us on Slack, and visit the OpenSSF Working Group responsible for maintaining this spec, [Metrics & Metadata](https://github.com/ossf/wg-metrics-and-metadata).

--- a/docs/user-story.md
+++ b/docs/user-story.md
@@ -25,8 +25,8 @@ then put under version control, provided to potential users, and updated as need
 The file's contents may then be extracted for a variety of different reasons (e.g., 
 extracted into security evaluations, etc.).
 
-This is an early version created by the OpenSSF Identifying Security Threats Working 
-Group. See the [OpenSSF Community Calendar](https://calendar.google.com/calendar?cid=czYzdm9lZmhwNWk5cGZsdGI1cTY3bmdwZXNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
+This is an early version created by the OpenSSF Metrics & Metadata working
+group. See the [OpenSSF Community Calendar](https://calendar.google.com/calendar?cid=czYzdm9lZmhwNWk5cGZsdGI1cTY3bmdwZXNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
 
 ## SECURITY-INSIGHTS.yml
 

--- a/docs/versioning-policy.md
+++ b/docs/versioning-policy.md
@@ -37,7 +37,7 @@ A patch release (e.g., from `1.1.0` to `1.1.1`) includes minor fixes, typo corre
 
 ### 3.4 Procedure for Major Releases:
 
-- Discuss and propose the changes through open-source project communication channels (GitHub repo [ossf/security-insights-spec](https://github.com/ossf/security-insights-spec), OpenSSF Slack channels [#wg_identifying_security_threats](https://openssf.slack.com/archives/C01A50B978T) and [#security_insights](https://openssf.slack.com/archives/C04BB493NET)).
+- Discuss and propose the changes through open-source project communication channels (GitHub repo [ossf/security-insights-spec](https://github.com/ossf/security-insights-spec), OpenSSF Slack channels [#wg_metrics_and_metadata](https://openssf.slack.com/archives/C01A50B978T) and [#security_insights](https://openssf.slack.com/archives/C04BB493NET)).
 - Conduct a review and discussion among community, and OpenSSF working groups.
 - Update the project with proposed changes, and update the changelog.
 - Release the updates through GitHub Release.

--- a/specification.md
+++ b/specification.md
@@ -8,7 +8,7 @@ Example implementations can be found on the specification's [GitHub repository](
 
 A collection of unofficial supplemental tooling can be found in the ["SI Tooling" GitHub Repository](https://github.com/ossf/si-tooling).
 
-Maintenance for the specification is led by the [OpenSSF Identifying Security Threats Working Group](https://github.com/ossf/wg-identifying-security-threats), and improvements are handled exclusively within the project's GitHub repository. Additional information about contribution can be found within the project's [Contribution Policy](/CONTRIBUTING.md).
+Maintenance for the specification is led by the OpenSSF [Metrics & Metadata working group](https://github.com/ossf/wg-metrics-and-metadata), and improvements are handled exclusively within the project's GitHub repository. Additional information about contribution can be found within the project's [Contribution Policy](/CONTRIBUTING.md).
 
 Improvement suggestions and clarification requests can be logged as [GitHub Issues](https://github.com/ossf/security-insights-spec/issues/new), raised as discussion on [Slack](https://openssf.slack.com/messages/security_insights/), or discussed with the community in the appropriate Working Group meeting from the [OpenSSF Community Calendar](https://calendar.google.com/calendar?cid=czYzdm9lZmhwNWk5cGZsdGI1cTY3bmdwZXNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
 
@@ -16,7 +16,7 @@ This specification follows semantic versioning. Changes made to the schema on Gi
 
 Any security-related issues related to the specification or maintenance thereof should follow the recommendations outlined in the project's [security policy](./SECURITY.md).
 
-This specification subject to the Community Specification License 1.0 available at https://github.com/CommunitySpecification/1.0.
+This specification subject to the Community Specification License 1.0 available at <https://github.com/CommunitySpecification/1.0>.
 
 
 ## Specification


### PR DESCRIPTION
This PR renames "Identifying Security Threats" to "Metrics & Metadata" in the various docs in this repo.