### PR TITLE
Make the SIEP template valid YAML syntax

### DIFF
--- a/.github/ISSUE_TEMPLATE/siep.yml
+++ b/.github/ISSUE_TEMPLATE/siep.yml
@@ -68,5 +68,5 @@ body:
         - label: No Sponsor Yet
           value: None
         - label: Eddie Knight
-          value: @eddie-knight
+          value: "@eddie-knight"
       required: true


### PR DESCRIPTION
I noticed it was invalid when attempting to create a new SIEP issue using the template. The Github issue form shows a visible error and running yamllint against it confirms the issue.

<img width="1009" alt="Screenshot 2025-03-27 at 5 39 46 PM" src="https://github.com/user-attachments/assets/d9d4413f-cf18-4732-8d19-c42438bce66c" />
