### PR TITLE
Adding project.documentation.support-policy to schema

### DIFF
--- a/schema.cue
+++ b/schema.cue
@@ -85,6 +85,7 @@ project?: {
     "code-of-conduct"?:        #URL
     "quickstart-guide"?:       #URL
     "release-process"?:        #URL
+    "support-policy"?:         #URL
     "signature-verification"?: #URL
   }
 }

--- a/specification/project.md
+++ b/specification/project.md
@@ -128,6 +128,11 @@ An object containing references to key documentation URLs.
 - **Type**: [URL]
 - **Description**: URL describing how releases are planned, prepared, and published.
 
+### `project.documentation.support-policy` (optional)
+
+- **Type**: [URL]
+- **Description**: URL to documentation describing how releases are supported. See [Recommendations for publishing End-of-life dates and support timelines](https://endoflife.date/recommendations) for best practices.
+
 ### `project.documentation.signature-verification` (optional)
 
 - **Type**: [URL]

--- a/template-full.yml
+++ b/template-full.yml
@@ -29,6 +29,7 @@ project:
     detailed-guide: https://example.com/user-guide
     code-of-conduct: https://example.com/code-of-conduct.html
     release-process: https://example.com/release-process
+    support-policy: https://example.com/support-policy
     signature-verification: https://example.com/signature-verification
   repositories:
     - name: Foo


### PR DESCRIPTION
This implements the design proposed in and closes https://github.com/ossf/security-insights-spec/issues/112

Once these changes land, here is how I imagine the field could be adopted by 2 projects that have previously adopted `security-insights.yml`

[Cilium project](https://github.com/cilium/cilium/blob/main/SECURITY-INSIGHTS.yml)
```yaml
project:
  name: Cilium
  homepage: https://cilium.io
  roadmap: https://docs.cilium.io/en/stable/community/roadmap/
  # ...
  documentation:
    quickstart-guide: https://docs.cilium.io/en/stable/#getting-started
    detailed-guide: https://docs.cilium.io/en/stable/
    code-of-conduct: https://github.com/cilium/cilium/tree/main?tab=coc-ov-file#readme
    release-process: https://docs.cilium.io/en/stable/contributing/release/
    support-policy: https://github.com/cilium/cilium/tree/main?tab=readme-ov-file#stable-releases
```

[Envoy project](https://github.com/envoyproxy/envoy/blob/main/SECURITY-INSIGHTS.yml)
```yaml
project:
  name: Envoy
  homepage: https://www.envoyproxy.io/
  roadmap: https://docs.cilium.io/en/stable/community/roadmap/
  # ...
  documentation:
    detailed-guide: https://www.envoyproxy.io/
    code-of-conduct: https://github.com/envoyproxy/envoy?tab=coc-ov-file#readme
    support-policy: https://github.com/envoyproxy/envoy/blob/main/RELEASES.md
```

And, here are some examples of how other projects who have yet to adopt `security-insights.yml` might adopt it:

[Fluentd](https://www.fluentd.org/)
 ```yaml
support-policy: https://github.com/fluent/fluentd?tab=security-ov-file#readme
 ```

[Istio](https://istio.io/)
```yaml
support-policy: https://istio.io/latest/docs/releases/supported-releases/
```

[dapr](https://github.com/dapr/dapr)
```yaml
support-policy: https://docs.dapr.io/operations/support/support-release-policy/
```



