### PR TITLE
Constrain the schema version in the header more clearly

### DIFF
--- a/schema.cue
+++ b/schema.cue
@@ -7,6 +7,7 @@ import (
 #URL: =~"^https?://[^\\s]+$"
 #Email: =~"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
 #Date: time.Format("2006-01-02")
+#SchemaVersion: =~"^[1-9]+\\.[0-9]+\\.[0-9]+$"
 
 #Assessment: {
   comment:   string
@@ -45,7 +46,7 @@ import (
 header: {
   "last-reviewed":      #Date
   "last-updated":       #Date
-  "schema-version":     string
+  "schema-version":     #SchemaVersion
   url:                  #URL
   comment?:             string
   "project-si-source"?: #URL

--- a/specification/aliases.md
+++ b/specification/aliases.md
@@ -112,8 +112,13 @@ A list of objects describing various release attestations or artifacts.
   - **Type**: `string`
   - **Matches Pattern**: `^https?://[^\\s]+$`
 
+### `schemaversion`
+
+  - **Type**: `string`
+  - **Matches Pattern**: `^[1-9]+\\.[0-9]+\\.[0-9]+$`
 ---
 
 [URL]: #url
 [Email]: #email
 [Date]: #date
+[SchemaVersion]: #schemaversion

--- a/specification/header.md
+++ b/specification/header.md
@@ -20,7 +20,7 @@ The `header` object captures high-level metadata about the schema.
 
 ## `header.schema-version`
 
-- **Type**: `string`
+- **Type**: [SchemaVersion]
 - **Description**: Represents the version of this schema.
 
 ---
@@ -49,3 +49,4 @@ The `header` object captures high-level metadata about the schema.
 [URL]: ./aliases.md#url
 [Email]: ./aliases.md#email
 [Date]: ./aliases.md#date
+[SchemaVersion]: ./aliases.md#schemaversion


### PR DESCRIPTION
This change modifies the cue schema to clearly set the expectation that the header's schema version be >= 1.0.0