### PR TITLE
Further clarify/constrain the cue schema for Project

### DIFF
--- a/schema.cue
+++ b/schema.cue
@@ -57,13 +57,13 @@ project?: {
   roadmap?:    #URL
   funding?:    #URL
 
-  administrators: [...#Contact]
+  administrators: [#Contact, ...]
 
-  repositories: [...{
+  repositories: [{
     name:    string
     comment: string
     url:     #URL
-  }]
+  }, ...]
 
   "vulnerability-reporting": {
     "reports-accepted":        bool

--- a/specification/project.md
+++ b/specification/project.md
@@ -32,13 +32,13 @@ Optional:
 ## `project.administrators`
 
 - **Type**: `slice` of [Contact]
-- **Description**: A list of individuals who have administrative access to the project's resources.
+- **Description**: A list of 1 or more individuals who have administrative access to the project's resources.
 
 ---
 
 ## `project.repositories`
 
-A list repositories that are part of this project, including the repository this file is published in.
+A list of 1 or more repositories that are part of this project, including the repository this file is published in.
 
 - `repositories[].name`
   - **Type**: `string`


### PR DESCRIPTION
This PR constrains how "open" the `administrators` and `repositories` list types are defined in the schema.

With their previous definitions, the following project was valid according to the schema:

```yaml
project:
  name: example
  administrators: []
  repositories: []
  vulnerability-reporting:
    reports-accepted: true
    bug-bounty-available: true
```

Given that the `template-minimum.yml` already illustrates this constraint and it makes logical sense, it is included in the cue schema and the Markdown docs for Project are updated to note the required list size of 1 for each list.