### PR TITLE
Further clarify/constrain the cue schema for Repository

### DIFF
--- a/schema.cue
+++ b/schema.cue
@@ -96,7 +96,7 @@ repository?: {
   "bug-fixes-only"?:                   bool
   "no-third-party-packages"?:          bool
 
-  "core-team": [...#Contact]
+  "core-team": [#Contact, ...]
 
   license: #License
 
@@ -114,7 +114,7 @@ repository?: {
       version?: string
       comment?: string
 
-      rulesets: [...string]
+      rulesets: ["default"] | [...string]
 
       integration: {
         adhoc:   bool
@@ -142,7 +142,7 @@ repository?: {
   release?: {
     "automated-pipeline": bool
 
-    "distribution-points": [...#Link]
+    "distribution-points": [#Link, ...]
 
     changelog?:    #URL
     license?:      #License

--- a/specification/repository.md
+++ b/specification/repository.md
@@ -71,7 +71,7 @@ Optional top-level fields:
 ## `repository.core-team`
 
 - **Type**: `slice` of [Contact]
-- **Description**: A list of core team members for this repository, such as maintainers or approvers.
+- **Description**: A list of 1 or more core team members for this repository, such as maintainers or approvers.
 
 ---
 
@@ -183,7 +183,7 @@ An object describing release-related details for this repository.
 ### `release.distribution-points`
 
 - **Type**: `slice` of [Link]
-- **Description**: A list of links describing where the repository’s releases are distributed. This may be the VCS releases page, a package manager, or other distribution points.
+- **Description**: A list of 1 or more links describing where the repository’s releases are distributed. This may be the VCS releases page, a package manager, or other distribution points.
 
 ### `release.changelog` (optional)
 


### PR DESCRIPTION
This PR constrains how "open" the list types:

 - `core-team`
 - `security.tools.rulesets`
 - `release.distribution-points`

are within the schema.

With the previous definitions, the following
repository was valid according to the schema:

```yaml
repository:
  url: https://my.vcs/foobar/foo
  status: active
  accepts-change-request: true
  accepts-automated-change-request: true
  core-team: []
  license:
    url: https://foo.bar/LICENSE
    expression: MIT
  security:
    assessments:
      self:
        comment: |
          Self assessment has not yet been completed.
    tools:
      name: example
      type: SCA
      rulesets: []
      integration:
        adhoc: true
        ci: true
        release: true
  release:
    automated-pipeline: true
    distribution-points: []
```

With these changes, these list types now require that each list have at least a single item present