### PR TITLE
SIEP-106 changes and related content updates

### DIFF
--- a/.github/security-insights.yml
+++ b/.github/security-insights.yml
@@ -16,6 +16,11 @@ project:
       url: https://github.com/ossf/security-insights-spec
       comment: |
         Security Insights is the core repo for the Security Insights project.
+  steward:
+    - uri: https://openssf.org
+      comment: |
+        The Security Insights Specification is a copyright of the Open Source Security Foundation (OpenSSF)
+        and it is maintained by volunteers under the oversight of the OpenSSF.
   vulnerability-reporting:
     reports-accepted: true
     bug-bounty-available: false

--- a/schema.cue
+++ b/schema.cue
@@ -53,10 +53,11 @@ header: {
 }
 
 project?: {
-  name:        string
-  homepage?:   #URL
-  roadmap?:    #URL
-  funding?:    #URL
+  name:      string
+  homepage?: #URL
+  roadmap?:  #URL
+  funding?:  #URL
+  steward?:  #Link
 
   administrators: [#Contact, ...]
 

--- a/specification/project.md
+++ b/specification/project.md
@@ -159,7 +159,7 @@ An object containing references to key documentation URLs.
 ## `project.steward` (optional)
 
 - **Type**: [Link]
-- **Description**: A link and description of the relationship this project has with a parent entity, such as an open source foundation.
+- **Description**: This field is to communicate the relationship between the project and "a legal person, other than a manufacturer, that has the purpose or objective of systematically providing support on a sustained basis for the development of specific products with digital elements, qualifying as free and open-source software and intended for commercial activities, and that ensures the viability of those products" This definition is drawn from the [European Union Cyber Resilience Act, Article 3](https://eur-lex.europa.eu/eli/reg/2024/2847/oj/eng#art_3).
 
 [URL]: ./aliases.md#url
 [Contact]: ./aliases.md#contact

--- a/specification/project.md
+++ b/specification/project.md
@@ -19,6 +19,7 @@ Optional:
 - `funding`
 - `roadmap`
 - `documentation`
+- `steward`
 
 ---
 
@@ -155,5 +156,11 @@ An object containing references to key documentation URLs.
 
 ---
 
+## `project.steward` (optional)
+
+- **Type**: [Link]
+- **Description**: A link and description of the relationship this project has with a parent entity, such as an open source foundation.
+
 [URL]: ./aliases.md#url
 [Contact]: ./aliases.md#contact
+[Link]: ./aliases.md#link

--- a/template-full.yml
+++ b/template-full.yml
@@ -14,6 +14,10 @@ project:
   homepage: https://foo.bar
   funding: https://foo.bar/FUNDING.yml
   roadmap: https://foo.bar/roadmap.html
+  steward:
+    uri: https://foo.bar
+    comment: |
+      Some description of the relationship between this project and its steward.
   administrators:
     - name: Joe Dohn
       affiliation: Foo


### PR DESCRIPTION
Part of #106

## Copilot Summary

This pull request introduces the concept of a "steward" to the project schema and documentation. The most important changes include updates to the schema definition, documentation, and example templates to incorporate the new `steward` field.

Schema and Documentation Updates:

* [`schema.cue`](diffhunk://#diff-fdc23bbcbafda7a99dda5a1b79a812ea24ca20bc29edb48a501a0ffd09b4f13cR60): Added the optional `steward` field to the project schema.
* [`specification/project.md`](diffhunk://#diff-72b3459292b560ecf16b2f36cf48c01eaccd614e1384f67bdf95742f2d3d5f70R22): Updated the project specification to include the `steward` field, describing its type and purpose. [[1]](diffhunk://#diff-72b3459292b560ecf16b2f36cf48c01eaccd614e1384f67bdf95742f2d3d5f70R22) [[2]](diffhunk://#diff-72b3459292b560ecf16b2f36cf48c01eaccd614e1384f67bdf95742f2d3d5f70R159-R166)

Content Updates:

* [`.github/security-insights.yml`](diffhunk://#diff-1f5aa375a61288f277949ae8b01f35276656fcd22072a513ac3ed1b62b6e1134R19-R23): Added the `steward` field to the Security Insights project configuration.
* [`template-full.yml`](diffhunk://#diff-560718b00639d3ff5fe33d2b759cbaf972b07a7e88ac3e1acbef45525b8529c5R17-R20): Added the `steward` field to the full project template with an example description.