### PR TITLE
fix: correct errors in file preventing schema validation

### DIFF
--- a/.github/security-insights.yml
+++ b/.github/security-insights.yml
@@ -17,10 +17,9 @@ project:
       comment: |
         Security Insights is the core repo for the Security Insights project.
   steward:
-    - uri: https://openssf.org
+      uri: https://openssf.org
       comment: |
-        The Security Insights Specification is a copyright of the Open Source Security Foundation (OpenSSF)
-        and it is maintained by volunteers under the oversight of the OpenSSF.
+        The Security Insights Specification is a copyright of the Open Source Security Foundation (OpenSSF) and it is maintained by volunteers under the oversight of the OpenSSF.
   vulnerability-reporting:
     reports-accepted: true
     bug-bounty-available: false
@@ -49,7 +48,7 @@ repository:
     contributing-guide: https://github.com/ossf/security-insights-spec/blob/main/.github/CONTRIBUTING.md
     governance: https://github.com/ossf/security-insights-spec/blob/main/docs/GOVERNANCE.md
   release:
-    automated-pipeleine: false
+    automated-pipeline: false
     distribution-points:
       - uri:  https://github.com/ossf/security-insights-spec/releases
         comment: GitHub Release Page

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
         uses: cue-lang/setup-cue@v1.0.0
         with:
           cue-version: 0.11.0
+      
+      - name: Validate our security-insights.yml
+        run: cue vet .github/security-insights.yml schema.cue
 
       - name: Validate template-full.yml
         run: cue vet template-full.yml schema.cue


### PR DESCRIPTION
This PR corrects the data type of `project.steward` and fixes a spelling error in `repository.release.automated-pipeline`

To prevent further such problems escaping our notice, the CI workflow has been updated to validate `.github/security-insights.yml` against the schema.