### PR TITLE
fix: move @go package annotation in schema

### DIFF
--- a/schema.cue
+++ b/schema.cue
@@ -1,9 +1,9 @@
 package security_insights_spec
-@go("si") // this doesn't appropriately override the package name in the generated code currently due to a bug in cue
 
 import (
   "time"
 )
+@go("si")
 
 #URL: =~"^https?://[^\\s]+$"
 #Email: =~"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"


### PR DESCRIPTION
This change is based on feedback from the cuelang
maintainers on the issue I filed. They kindly
pointed me in this direction.

I tested this change by running `make cuegen` and
observing that the resultant `cue_types_gen.go`
begins with:

```go
// Code generated by "cue exp gengotypes"; DO NOT EDIT.

package si
```

whereas previously it would have been:

```go
// Code generated by "cue exp gengotypes"; DO NOT EDIT.

package security_insights_spec