### PR TITLE
feature: make a CUE module (WIP)

### DIFF
--- a/cue.mod/module.cue
+++ b/cue.mod/module.cue
@@ -1,0 +1,7 @@
+module: "github.com/ossf/security-insights-spec"
+language: {
+	version: "v0.11.0"
+}
+source: {
+	kind: "git"
+}


### PR DESCRIPTION
This work-in-progress PR builds on top of #138 (hence the "repetition" of the commits in this PR) to demonstrate the change required to publish this module to the CUE Central Registry. 

The only change required was to make this repo a CUE module: that's it!

As a demonstration of what's possible once published as a module, I published the code to a "scratch" namespace. Now you can do something like:

```
cue vet -d '#SecurityInsights' github.com/cue-tmp/scratch/security-insights-spec@v0.0.0:security_insights_spec my-file.yml
```