### PR TITLE
ci: Add scanner for OSPS baseline

### DIFF
--- a/.github/workflows/baseline.yml
+++ b/.github/workflows/baseline.yml
@@ -1,0 +1,37 @@
+name: OSPS Baseline Scanner
+
+on:
+  schedule:
+    # Run weekly on Mondays at 9 AM UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  osps-assessment:
+    runs-on: ubuntu-latest
+    name: Baseline Scan
+
+    permissions:
+      contents: read
+      security-events: write # Required for SARIF upload
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Run Baseline Action
+        uses: revanite-io/osps-baseline-action@ffcef1f33b6ee5b916c7e357e4ae1481b99b46b6 # v1.0.0
+        with:
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          token: ${{ secrets.PVTR_GITHUB_TOKEN }}
+          catalog: "osps-baseline"
+          upload-sarif: "true"
+
+      - name: Upload Assessment Results
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: osps-assessment-results-${{ github.run_number }}
+          path: evaluation_results/
+          retention-days: 1


### PR DESCRIPTION
copied from Gemara, so the GH token should be in place for the org already.

https://github.com/ossf/gemara/blob/main/.github/workflows/baseline-scanner.yml