### PR TITLE
fix: issue template options

### DIFF
--- a/.github/ISSUE_TEMPLATE/siep.yml
+++ b/.github/ISSUE_TEMPLATE/siep.yml
@@ -71,9 +71,7 @@ body:
       description: Select the maintainer sponsoring this proposal.
       multiple: false
       options:
-        - label: No Sponsor Yet
-          value: None
-        - label: Eddie Knight
-          value: "@eddie-knight"
+        - No Sponsor Yet
+        - Eddie Knight (@eddie-knight)
     validations:
       required: true


### PR DESCRIPTION
This PR fixes the "Sponsoring Maintainer" dropdown in the SIEP issue template.

Current:
<img width="974" height="268" alt="image" src="https://github.com/user-attachments/assets/aabf75be-a2e2-40f9-92e9-ccc7c1a20b44" />

As per <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository>, the options should just be something like:

```
options:
  - first option
  - second option
```