### PR TITLE
fix: remove verbose option from cue vet in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 lintcue:
 	@echo "  >  Linting CUE schema ..."
 	@cd spec
-	@cue vet ./spec --all-errors --verbose
+	@cue vet ./spec --all-errors
 
 lintyml:
 	@echo "  >  Linting YAML files ..."


### PR DESCRIPTION
Deemed unnecessary in https://github.com/cue-lang/cue/issues/3047