### PR TITLE
feat: disclose agent-assisted production

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -30,6 +30,18 @@ project describes the overall project, including basic info, documentation links
 
 repository describes repository-related configurations, including status, policies, team members, documentation, license, releases, and security posture. This field is not required if `header.project-si-source` is supplied. This field is required if the file is intended for use as a parent security insights file with project information to be inherited by multiple repositories via their respective `header.project-si-source`.
 
+## #AgentAssistedProduction
+
+AgentAssistedProduction describes whether this project uses automated agents in production workflows and, optionally, where users can read the project's governance declaration for those workflows.
+
+`used` **boolean** _Required_
+
+Indicates whether the project uses automated agents in production workflows such as code generation, review, release preparation, triage, policy checks, or operational actions.
+
+`governance-declaration` **[URL](#url)**
+
+Optional URL to a project-maintained governance declaration. The declaration may describe review requirements, approved agent use cases, logging, attestations, receipts, policies, or other controls. Security Insights does not prescribe the declaration's format.
+
 ## #Assessment
 
 Assessment represents the results of a security assessment, including comments, evidence, and date.
@@ -149,6 +161,10 @@ Project describes the overall project, including basic info, documentation links
 `administrators` **array[[Contact](#contact)]** _Required_
 
 A list of 1 or more individuals who have administrative access to the project's resources.
+
+`agent-assisted-production` **[AgentAssistedProduction](#agentassistedproduction)**
+
+Optional disclosure of agent-assisted production use at the project level.
 
 `name` **string** _Required_
 
@@ -489,6 +505,7 @@ URL is a TLS URL
 ---
 
 
+[AgentAssistedProduction]: #agentassistedproduction
 [Header]: #header
 [Project]: #project
 [SchemaVersion]: #schemaversion

--- a/examples/example-agent-assisted-production.yml
+++ b/examples/example-agent-assisted-production.yml
@@ -1,0 +1,27 @@
+header:
+  schema-version: 2.2.0
+  last-updated: '2026-04-30'
+  last-reviewed: '2026-04-30'
+  url: https://example.com/.github/security-insights.yml
+
+project:
+  name: Example Project
+  homepage: https://example.com
+  administrators:
+    - name: Example Security Team
+      email: security@example.com
+      primary: true
+  repositories:
+    - name: example-project
+      url: https://github.com/example/project
+      comment: Main project repository.
+  vulnerability-reporting:
+    reports-accepted: true
+    bug-bounty-available: false
+    contact:
+      name: Example Security Team
+      email: security@example.com
+      primary: true
+  agent-assisted-production:
+    used: true
+    governance-declaration: https://example.com/.well-known/agent-governance

--- a/examples/example-full.yml
+++ b/examples/example-full.yml
@@ -18,6 +18,9 @@ project:
     uri: https://example.com
     comment: |
       Some description of the relationship between this project and its steward.
+  agent-assisted-production:
+    used: true
+    governance-declaration: https://example.com/.well-known/agent-governance
   administrators:
     - name: Joe Dohn
       affiliation: Foo

--- a/spec/schema.cue
+++ b/spec/schema.cue
@@ -189,6 +189,24 @@ import (
 	"out-of-scope"?: [...string] @go(OutOfScope,type=*URL)
 }
 
+
+// AgentAssistedProduction describes whether this project uses automated
+// agents in production workflows and, optionally, where users can read
+// the project's governance declaration for those workflows.
+#AgentAssistedProduction: {
+
+	// Indicates whether the project uses automated agents in production
+	// workflows such as code generation, review, release preparation,
+	// triage, policy checks, or operational actions.
+	used: bool
+
+	// Optional URL to a project-maintained governance declaration. The
+	// declaration may describe review requirements, approved agent use
+	// cases, logging, attestations, receipts, policies, or other controls.
+	// Security Insights does not prescribe the declaration's format.
+	"governance-declaration"?: #URL @go(GovernanceDeclaration,type=*URL)
+}
+
 // Project describes the overall project, including basic info, documentation links, repositories, vulnerability reporting, and security details.
 #Project: {
 
@@ -206,6 +224,9 @@ import (
 
 	// This field is to communicate the relationship between the project and "a legal person, other than a manufacturer, that has the purpose or objective of systematically providing support on a sustained basis for the development of specific products with digital elements, qualifying as free and open-source software and intended for commercial activities, and that ensures the viability of those products" This definition is drawn from the [European Union Cyber Resilience Act, Article 3](https://eur-lex.europa.eu/eli/reg/2024/2847/oj/eng#art_3).
 	steward?: #Link @go(Steward,type=*Link)
+
+	// Optional disclosure of agent-assisted production use at the project level.
+	"agent-assisted-production"?: #AgentAssistedProduction @go(AgentAssistedProduction,type=*AgentAssistedProduction)
 
 	// A list of 1 or more individuals who have administrative access to the project's resources.
 	administrators: [#Contact, ...] @go(,type=[]Contact)

--- a/spec/schema.md
+++ b/spec/schema.md
@@ -23,6 +23,18 @@ project describes the overall project, including basic info, documentation links
 
 repository describes repository-related configurations, including status, policies, team members, documentation, license, releases, and security posture. This field is not required if `header.project-si-source` is supplied. This field is required if the file is intended for use as a parent security insights file with project information to be inherited by multiple repositories via their respective `header.project-si-source`.
 
+## #AgentAssistedProduction
+
+AgentAssistedProduction describes whether this project uses automated agents in production workflows and, optionally, where users can read the project's governance declaration for those workflows.
+
+`used` **boolean** _Required_
+
+Indicates whether the project uses automated agents in production workflows such as code generation, review, release preparation, triage, policy checks, or operational actions.
+
+`governance-declaration` **[URL](#url)**
+
+Optional URL to a project-maintained governance declaration. The declaration may describe review requirements, approved agent use cases, logging, attestations, receipts, policies, or other controls. Security Insights does not prescribe the declaration's format.
+
 ## #Assessment
 
 Assessment represents the results of a security assessment, including comments, evidence, and date.
@@ -142,6 +154,10 @@ Project describes the overall project, including basic info, documentation links
 `administrators` **array[[Contact](#contact)]** _Required_
 
 A list of 1 or more individuals who have administrative access to the project's resources.
+
+`agent-assisted-production` **[AgentAssistedProduction](#agentassistedproduction)**
+
+Optional disclosure of agent-assisted production use at the project level.
 
 `name` **string** _Required_
 
@@ -482,6 +498,7 @@ URL is a TLS URL
 ---
 
 
+[AgentAssistedProduction]: #agentassistedproduction
 [Header]: #header
 [Project]: #project
 [SchemaVersion]: #schemaversion


### PR DESCRIPTION
## Summary

Adds an optional project-level `agent-assisted-production` disclosure field with a deliberately small, vendor-neutral shape:

```yaml
project:
  agent-assisted-production:
    used: true
    governance-declaration: https://example.com/.well-known/agent-governance
```

The field lets a project disclose whether automated agents are used in production workflows and, if useful, point readers to a project-maintained governance declaration.

## Design choices

- Project-level first, because agent-assisted production often spans multiple repositories and workflows.
- Optional and backward-compatible.
- Does not prescribe a specific receipt format, policy engine, attestation framework, or vendor.
- Framework-specific details stay behind the optional `governance-declaration` URI.

## Validation

- `go run cuelang.org/go/cmd/cue@latest vet -d '#SecurityInsights' ./spec examples/example-full.yml`
- `go run cuelang.org/go/cmd/cue@latest vet -d '#SecurityInsights' ./spec examples/example-agent-assisted-production.yml`

Context: follows discussion in #171.