### PR TITLE
chore: bump example schema-version to 2.2.0

### DIFF
--- a/examples/example-full.yml
+++ b/examples/example-full.yml
@@ -1,5 +1,5 @@
 header:
-  schema-version: 2.0.0
+  schema-version: 2.2.0
   last-updated: '2025-03-01'
   last-reviewed: '2025-04-01'
   url: https://example.com/foo/bar/raw/branch/main/security-insights.yml

--- a/examples/example-minimum.yml
+++ b/examples/example-minimum.yml
@@ -1,5 +1,5 @@
 header:
-  schema-version: 2.0.0
+  schema-version: 2.2.0
   last-updated: '2025-03-01'
   last-reviewed: '2025-04-01'
   url: https://example.com/foo/bar/raw/branch/main/security-insights.yml

--- a/examples/example-multi-repository-project-reuse.yml
+++ b/examples/example-multi-repository-project-reuse.yml
@@ -1,7 +1,7 @@
 # Repository template for a multi-repository project
 # This file would be stored in the https://example.com/foobar/bar repository
 header:
-  schema-version: 2.0.0
+  schema-version: 2.2.0
   last-updated: '2025-03-01'
   last-reviewed: '2025-04-01'
   url: https://example.com/foo/bar/raw/branch/main/security-insights.yml

--- a/examples/example-multi-repository-project.yml
+++ b/examples/example-multi-repository-project.yml
@@ -2,7 +2,7 @@
 # This file would be stored in the https://example.com/foobar/foo repository
 # and addressable via https://example.com/foobar/foo/security-insights.yml
 header:
-  schema-version: 2.0.0
+  schema-version: 2.2.0
   last-updated: '2025-03-01'
   last-reviewed: '2025-04-01'
   url: https://example.com/foo/bar/raw/branch/main/security-insights.yml


### PR DESCRIPTION
The four example files all advertised schema-version 2.0.0, two minor versions behind the current spec (VERSION: v2.2.0). Readers copying these as templates would start out on a stale schema. Update the header.schema-version in each example to match the current release.