### PR TITLE
chore: refresh security-insights.yml metadata

### DIFF
--- a/.github/security-insights.yml
+++ b/.github/security-insights.yml
@@ -1,8 +1,8 @@
 header:
-  schema-version: 2.0.0
-  last-updated: '2024-12-31'
-  last-reviewed: '2025-01-01'
-  url: https://github.com/ossf/security-insights-spec
+  schema-version: 2.2.0
+  last-updated: '2026-05-08'
+  last-reviewed: '2026-05-08'
+  url: https://github.com/ossf/security-insights
   comment: This file contains the security information for the Security Insights project.
 
 project:
@@ -15,7 +15,7 @@ project:
     quickstart-guide: https://github.com/ossf/security-insights?tab=readme-ov-file#quick-start
   repositories:
     - name: Security Insights
-      url: https://github.com/ossf/security-insights-spec
+      url: https://github.com/ossf/security-insights
       comment: |
         Security Insights is the core repo for the Security Insights project.
   steward:
@@ -32,7 +32,7 @@ project:
 
 repository:
   status: active
-  url: https://github.com/ossf/security-insights-spec
+  url: https://github.com/ossf/security-insights
   accepts-change-request: true
   accepts-automated-change-request: false
   no-third-party-packages: true
@@ -43,20 +43,19 @@ repository:
     - name:        Jason Meridth
       affiliation: Chainguard
   license:
-    url: https://github.com/ossf/security-insights-spec/blob/main/LICENSE
+    url: https://github.com/ossf/security-insights/blob/main/LICENSE
     expression: MIT AND Community Specification License 1.0
   security:
     assessments:
       self:
-        evidence: https://github.com/ossf/security-insights-spec/blob/main/docs/threat-model
         comment: |
           A light-weight threat model was completed when the project was first started,
           and it remains accurate to-date.
   documentation:
-    contributing-guide: https://github.com/ossf/security-insights-spec/blob/main/.github/CONTRIBUTING.md
-    governance: https://github.com/ossf/security-insights-spec/blob/main/docs/GOVERNANCE.md
+    contributing-guide: https://github.com/ossf/security-insights/blob/main/.github/CONTRIBUTING.md
+    governance: https://github.com/ossf/security-insights/blob/main/docs/GOVERNANCE.md
   release:
     automated-pipeline: false
     distribution-points:
-      - uri:  https://github.com/ossf/security-insights-spec/releases
+      - uri:  https://github.com/ossf/security-insights/releases
         comment: GitHub Release Page


### PR DESCRIPTION
The repo's own security-insights.yml had drifted: the URLs referenced the pre-rename `ossf/security-insights-spec` repo (now redirects), last-updated/last-reviewed dates were 16+ months stale, schema-version was pinned to 2.0.0 while the project is at 2.2.0, and the self assessment evidence URL pointed at a docs/threat-model directory that does not exist in this repo. Drop the dangling evidence URL and bring URLs, dates, and schema-version current.