### PR TITLE
fix: correct LICENSE link in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Please adhere to our [Code of Conduct](https://github.com/ossf/.github/CODE_OF_C
 
 ## Licensing
 
-By contributing, you agree that your contributions will be licensed under the [project's license](LICENSE.md).
+By contributing, you agree that your contributions will be licensed under the [project's license](../LICENSE).
 
 ## Thanks!
 


### PR DESCRIPTION
The licensing section linked to LICENSE.md, but the project's license file is plain LICENSE at the repo root (no .md extension). Since CONTRIBUTING.md lives under .github/, the working relative path is ../LICENSE.