### PR TITLE
fix: use placeholder repo URL in example-full.yml

### DIFF
--- a/examples/example-full.yml
+++ b/examples/example-full.yml
@@ -60,7 +60,7 @@ project:
       Lorum ipsum...
 
 repository:
-  url: https://github.com/kubernetes/kubernetes
+  url: https://example.com/foobar/foo
   status: active
   bug-fixes-only: false
   accepts-change-request: true


### PR DESCRIPTION
The example file referenced a real upstream project (github.com/kubernetes/kubernetes) for repository.url while every other URL in the same file used the placeholder example.com/foobar/foo.