### PR TITLE
ci: run editor test suite in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,18 @@ jobs:
       - name: Setup Cue
         uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
 
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install editor test dependencies
+        run: npm ci
+
+      - name: Test editor
+        run: make testeditor
+
       - name: Validate schema.cue
         run: make lintcue
 


### PR DESCRIPTION
Relates to #186

## What/Why

Restores the editor test steps that were dropped when the branch's `ci.yml` was removed during the #186 rename-conflict resolution (see https://github.com/ossf/security-insights/pull/186#issuecomment-5262770090). Without them, nothing in `tests/editor/` runs in CI and the schema-fallback drift check never executes, so a `spec/schema.cue` change could silently desync `docs/editor/js/schema-fallback.js`.

## Proof it works

`npm ci && make testeditor` pass locally: 22/22 tests, 0 failures, with `check-schema-fallback` chained ahead of `npm test`. The CI run on this PR should now show the editor test steps executing.

## Risk + AI role

Low -- adds three CI steps (pinned setup-node, `npm ci`, `make testeditor`), no runtime code changes. AI-assisted, applying the fix proposed in the review comment linked above.

## Review focus

Confirm the pinned `actions/setup-node` SHA matches v4.4.0 and that Node 22 with npm caching is the right setup for the suite.