### PR TITLE
fix(ci): use workflow GITHUB_TOKEN for OSPS baseline scanner

### DIFF
--- a/.github/workflows/baseline.yaml
+++ b/.github/workflows/baseline.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
-          token: ${{ secrets.GH_AUTH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           catalog: "osps-baseline"
           upload-sarif: "true"
 


### PR DESCRIPTION
Relates to #162

## What/Why

The weekly OSPS Baseline Scanner run fails with `401 Bad credentials` (run 32014268173) because `GH_AUTH_TOKEN` is not available to this repository: the repo has no repository-level Actions secrets, and the identical scorecard workflow using the same org secret succeeded 4 minutes before this repo's run failed, so the PAT itself is fine but this repo is not on the org secret's access list. This is the second PAT-availability failure for this workflow (see #162). Switching to the ephemeral workflow `GITHUB_TOKEN` removes the external secret dependency entirely.

## Proof it works

- Reproduced the failure locally: running the pinned `pvtr-github-repo-scanner:v0.28.0` image with an empty token produces the identical `failed to load payload for github-repo ... 401 Bad credentials` / exit 3 from the CI logs.
- End-to-end verified: a `workflow_dispatch` run of this exact change completed successfully (scan ran, results uploaded): https://github.com/jmeridth/security-insights/actions/runs/32191652313

## Risk + AI role

Low -- one-line change to a scheduled CI workflow that is currently fully broken. AI-assisted diagnosis and fix.

## Review focus

`GITHUB_TOKEN` lacks `administration: read`, so OSPS-AC-03.01/03.02 (default branch protection) degrade from a hard check to a "not observable with the current token" warning. A follow-up PR proposes Octo STS federation (as adopted in gemaraproj/go-gemara#116) to restore those scopes without a long-lived PAT.